### PR TITLE
fix update API response in Address/User/ratingReviews Controllers

### DIFF
--- a/controllers/addressController.js
+++ b/controllers/addressController.js
@@ -8,17 +8,23 @@ const { createCustomError } = require('../utils/errors/custom-error');
  * @param {Object} req - Express request object.
  * @param {Object} res - Express response object.
  */
-const createAddress = asyncWrapper(async (req, res) => {
+const createAddress = asyncWrapper(async (req, res, next) => {
   // Destructure required properties from the request body
   const { street, postalCode, state, city, userId } = req.body;
 
+  const existAddress = await Address.findOne({
+    where: {
+      street, postalCode, state, city, userId
+    }
+  });
+
+  if (existAddress) {
+    return next(createCustomError(`Address already exists`, 400));
+  }
+
   // Create a new address in the database
   const address = await Address.create({
-    street,
-    postalCode,
-    state,
-    city,
-    userId,
+    street, postalCode, state, city, userId
   });
 
   // Log the created address and send a success response
@@ -85,6 +91,16 @@ const updateAddress = asyncWrapper(async (req, res, next) => {
 
   // Destructure address properties from the request body
   const { street, postalCode, state, city, userId } = req.body;
+
+  const existAddress = await Address.findOne({
+    where: {
+      street, postalCode, state, city, userId
+    }
+  });
+
+  if (existAddress) {
+    return next(createCustomError('Nothing to update', 200));
+  }
 
   // Update the address in the database
   const [updatedRowCount] = await Address.update(

--- a/controllers/ratingReviewController.js
+++ b/controllers/ratingReviewController.js
@@ -86,6 +86,16 @@ const updateRatingReview = asyncWrapper(async (req, res, next) => {
   // Destructure ratingReview properties from the request body
   const { title, description, rating, userId, productId } = req.body;
 
+  const existRatingReview = await RatingReview.findOne({
+    where: {
+      title, description, rating, userId, productId
+    }
+  });
+
+  if (existRatingReview) {
+    return next(createCustomError('Nothing to update', 200));
+  }
+
   // Update the ratingReview in the database
   const [updatedRowCount] = await RatingReview.update(
     { title, description, rating, userId, productId },

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -2,6 +2,8 @@
 const { User, Address, RatingReview } = require('../models');
 const { asyncWrapper } = require('../middleware');
 const { createCustomError } = require('../utils/errors/custom-error');
+const bcrypt = require('bcrypt');
+
 
 /**
  * Creates a new user in the database.
@@ -118,6 +120,25 @@ const updateUser = asyncWrapper(async (req, res, next) => {
     imageUrl,
   } = req.body;
 
+  const existUser = await User.findOne({
+    where: {
+      firstName,
+      lastName,
+      email,
+      mobile,
+      dateOfBirth,
+      imageUrl,
+    }
+  });
+
+
+  const user = await User.findByPk(id);
+  const isPasswordValid = bcrypt.compareSync(password, user.password);
+
+
+  if (existUser && isPasswordValid) {
+    return next(createCustomError('Nothing to update', 200));
+  }
   // Update the user in the database
   const [updatedRowCount] = await User.update(
     { firstName, lastName, email, mobile, dateOfBirth, password, imageUrl },


### PR DESCRIPTION
Add compareSync method in login API to make sure the hashed password is equal to the real one
Fix update API response in Address/User/ratingReviews Controllers where I:
Update the response message when the user is not updated and add compareSync method
Update the response message when the ratingReview is not updated
Update the response message when the Address is not updated
Return address already exists for the user if he create the same address